### PR TITLE
Remove pkginfo mapping from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,6 @@
                 "media"
             ],
             [
-                "pkginfo",
-                "pkginfo"
-            ],
-            [
                 "shell",
                 "shell"
             ],


### PR DESCRIPTION
/pkginfo folder have been removed in the previous commit (https://github.com/bragento/magento-core/commit/81993054112e7cfed42e2729eaab91e7b91ef6a3)

We need to remove mapping from root compose.json to deploy magento/core.